### PR TITLE
feat: Implement foundational URL shortening logic

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Deploy Scalable TinyURL Service
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.13'
+
+      - name: Set up SAM
+        uses: aws-actions/setup-sam@v2
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Build SAM application
+        run: sam build --use-container
+
+      - name: Deploy SAM application
+        run: sam deploy --no-confirm-changeset --no-fail-on-empty-changeset

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,3 +32,4 @@ jobs:
 
       - name: Deploy SAM application
         run: sam deploy --no-confirm-changeset --no-fail-on-empty-changeset
+        

--- a/hello_world/app.py
+++ b/hello_world/app.py
@@ -2,41 +2,56 @@ import json
 import os
 import uuid
 import boto3
+import logging
+import validators
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
 
 
-# Initialize the DynamoDB client
 dynamodb = boto3.resource('dynamodb')
-table = dynamodb.Table(os.environ.get("TABLE_NAME"))
+short_url_table = dynamodb.Table(os.environ.get("URL_LOOKUP_TABLE_NAME_DYNAMODB"))
 
 
 def lambda_handler(event, context):
-   try:
-       # Get the long URL from the POST request body
-       body = json.loads(event.get("body", "{}"))
-       long_url = body.get("long_url")
+   logger.info(f"Received event: {event}")
 
+   try:
+
+       body = json.loads(event.get("body", "{}"))
+       long_url = body.get("url")
 
        if not long_url:
+           logger.error("Validation Error: The 'long_url' field was not found in the request body.")
+
            return {
                "statusCode": 400,
-               "body": json.dumps({"error": "long_url is a required field"}),
+                "body": json.dumps({"error": "No URL found in the request."}),
+           }
+       if not validators.url(long_url):
+           logger.error(f"Validation Error: The provided URL is not valid. URL: '{long_url}'")
+           return {
+               "statusCode": 400,
+               "body": json.dumps({"error": "The provided URL is not valid."}),
            }
 
 
-       # Generate a unique short ID (I will replace this with base62 later)
-       short_id = str(uuid.uuid4())[:7]
+       # TODO (tarik): Replace this with base62 logic
+       short_id = uuid.uuid4().hex[:7]
 
 
-       # Save the mapping to DynamoDB
-       table.put_item(
-           Item={
-               'id': short_id,
-               'long_url': long_url
-           }
+ 
+       item_to_save = {
+           'id': short_id,
+           'long_url': long_url
+       }
+       
+       logger.info(f"Saving new item to DynamoDB: {item_to_save}")
+ 
+       short_url_table.put_item(
+           Item=item_to_save
        )
 
-
-       # Construct the short URL to return to the user
        api_gateway_url = f"https://{event['requestContext']['domainName']}/{event['requestContext']['stage']}"
        short_url = f"{api_gateway_url}/{short_id}"
 
@@ -49,9 +64,9 @@ def lambda_handler(event, context):
            }),
        }
    except Exception as e:
-       print(f"Error: {e}")
+       logger.error(f"An unexpected error occurred: {e}")
        return {
            "statusCode": 500,
            "body": json.dumps({"error": "An internal error occurred"}),
        }
-
+   

--- a/hello_world/requirements.txt
+++ b/hello_world/requirements.txt
@@ -1,1 +1,3 @@
 requests
+boto3
+validators

--- a/template.yaml
+++ b/template.yaml
@@ -1,45 +1,63 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: >
-  sam-app
+ sam-app
 
-  Sample SAM Template for sam-app
+
+ Sample SAM Template for sam-app
+
 
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
-  Function:
-    Timeout: 3
+ Function:
+   Timeout: 3
 
-    # You can add LoggingConfig parameters such as the Logformat, Log Group, and SystemLogLevel or ApplicationLogLevel. Learn more here https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-function.html#sam-function-loggingconfig.
-    LoggingConfig:
-      LogFormat: JSON
+
+   # You can add LoggingConfig parameters such as the Logformat, Log Group, and SystemLogLevel or ApplicationLogLevel. Learn more here https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-function.html#sam-function-loggingconfig.
+   LoggingConfig:
+     LogFormat: JSON
 Resources:
-  HelloWorldFunction:
-    Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
-    Properties:
-      CodeUri: hello_world/
-      Handler: app.lambda_handler
-      Runtime: python3.13
-      Architectures:
-      - x86_64
-      Events:
-        HelloWorld:
-          Type: Api # More info about API Event Source: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
-          Properties:
-            Path: /hello
-            Method: get
+ HelloWorldFunction:
+   Type: AWS::Serverless::Function # More info about Function Resource: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#awsserverlessfunction
+   Properties:
+     CodeUri: hello_world/
+     Handler: app.lambda_handler
+     Runtime: python3.13
+     Architectures:
+     - x86_64
+     Environment:
+       Variables:
+         TABLE_NAME: !Ref UrlTable
+     Policies:
+       - DynamoDBCrudPolicy:
+          TableName: !Ref UrlTable
+     Events:
+       ShortenUrl:
+         Type: Api
+         Properties:
+           Path: /shorten
+           Method: post
+ UrlTable:
+   Type: AWS::Serverless::SimpleTable
+   Properties:
+     PrimaryKey: # <-- Correct indentation
+       Name: id
+       Type: String
+
 
 Outputs:
-  # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function
-  # Find out more about other implicit resources you can reference within SAM
-  # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
-  HelloWorldApi:
-    Description: API Gateway endpoint URL for Prod stage for Hello World 
-      function
-    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
-  HelloWorldFunction:
-    Description: Hello World Lambda Function ARN
-    Value: !GetAtt HelloWorldFunction.Arn
-  HelloWorldFunctionIamRole:
-    Description: Implicit IAM Role created for Hello World function
-    Value: !GetAtt HelloWorldFunctionRole.Arn
+ # ServerlessRestApi is an implicit API created out of Events key under Serverless::Function
+ # Find out more about other implicit resources you can reference within SAM
+ # https://github.com/awslabs/serverless-application-model/blob/master/docs/internals/generated_resources.rst#api
+ HelloWorldApi:
+      Description: API Gateway endpoint URL for Prod stage for Shorten URL function
+      Value: !Sub "https://{ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/shorten/"
+ HelloWorldFunction:
+   Description: Hello World Lambda Function ARN
+   Value: !GetAtt HelloWorldFunction.Arn
+ HelloWorldFunctionIamRole:
+   Description: Implicit IAM Role created for Hello World function
+   Value: !GetAtt HelloWorldFunctionRole.Arn
+
+
+

--- a/template.yaml
+++ b/template.yaml
@@ -27,7 +27,7 @@ Resources:
      - x86_64
      Environment:
        Variables:
-         TABLE_NAME: !Ref UrlTable
+         URL_LOOKUP_TABLE_NAME_DYNAMODB: !Ref UrlTable
      Policies:
        - DynamoDBCrudPolicy:
           TableName: !Ref UrlTable
@@ -58,6 +58,4 @@ Outputs:
  HelloWorldFunctionIamRole:
    Description: Implicit IAM Role created for Hello World function
    Value: !GetAtt HelloWorldFunctionRole.Arn
-
-
-
+   


### PR DESCRIPTION
In this PR, I've updated the template.yaml to define our DynamoDB table and the new POST /shorten API endpoint. I also added the necessary IAM policy to grant the Lambda function access to the new table.

The Python code in the Lambda function has been updated to handle the incoming POST request, generate a temporary unique ID, and save the URL mapping to DynamoDB.

This is ready for your review. After this is merged, I will create a new pull request to replace the temporary ID generation with the Base62 atomic counter logic.

Thanks!