### PR TITLE
feat: Implement redirection service for Milestone 3

### DIFF
--- a/redirect_service/app.py
+++ b/redirect_service/app.py
@@ -1,0 +1,47 @@
+import os
+import json
+import boto3
+import logging
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+dynamodb = boto3.resource('dynamodb')
+table = dynamodb.Table(os.environ.get("URL_LOOKUP_TABLE_NAME_DYNAMODB"))
+
+def redirect_handler(event, context):
+    logger.info(f"Received event: {event}")
+
+    try:
+        short_id = event['pathParameters']['short_id']
+        logger.info(f"Looking up short_id: {short_id}")
+
+        response = table.get_item(Key={'id': short_id})
+        
+        if 'Item' in response:
+            long_url = response['Item']['long_url']
+            logger.info(f"Found long_url: {long_url}. Redirecting...")
+            return {
+                'statusCode': 302,
+                'headers': {
+                    'Location': long_url
+                }
+            }
+        else:
+            logger.warning(f"short_id '{short_id}' not found in the database.")
+            return {
+                'statusCode': 404,
+                'body': json.dumps({'error': 'Short URL not found'})
+            }
+    except KeyError:
+        logger.error("'short_id' not found in pathParameters.")
+        return {
+            'statusCode': 400,
+            'body': json.dumps({'error': "Bad request: 'short_id' missing from path."})
+        }
+    except Exception as e:
+        logger.error(f"An unexpected error occurred: {e}")
+        return {
+            'statusCode': 500,
+            'body': json.dumps({'error': 'An internal error occurred'})
+        }

--- a/template.yaml
+++ b/template.yaml
@@ -37,6 +37,26 @@ Resources:
          Properties:
            Path: /shorten
            Method: post
+ RedirectFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: redirect_service/
+      Handler: app.redirect_handler
+      Runtime: python3.13
+      Architectures:
+        - x86_64
+      Environment:
+        Variables:
+          URL_LOOKUP_TABLE_NAME_DYNAMODB: !Ref UrlTable
+      Policies:
+        - DynamoDBReadPolicy:
+            TableName: !Ref UrlTable
+      Events:
+        Redirect:
+          Type: Api
+          Properties:
+            Path: /{short_id}
+            Method: get
  UrlTable:
    Type: AWS::Serverless::SimpleTable
    Properties:
@@ -57,4 +77,10 @@ Outputs:
     Value: !GetAtt ShortenUrlFunction.Arn
   ShortenUrlFunctionIamRole:
     Description: Implicit IAM Role created for Shorten URL function
-    Value: !GetAtt ShortenUrlFunctionRole.Arn   
+    Value: !GetAtt ShortenUrlFunctionRole.Arn
+  RedirectFunction:
+    Description: Redirect Lambda Function ARN
+    Value: !GetAtt RedirectFunction.Arn
+  RedirectFunctionIamRole:
+    Description: Implicit IAM Role created for Redirect function
+    Value: !GetAtt RedirectFunctionRole.Arn

--- a/tests/unit/test_redirect_handler.py
+++ b/tests/unit/test_redirect_handler.py
@@ -1,0 +1,43 @@
+import json
+import os
+import pytest
+from unittest.mock import MagicMock
+
+# Set a mock environment variable for the test session
+os.environ['URL_LOOKUP_TABLE_NAME_DYNAMODB'] = 'mock-table'
+    
+from redirect_service import app
+
+def test_redirect_handler_happy_path(mocker):
+    """Verifies a 302 redirect is returned for a valid short_id."""
+    # Mock the DynamoDB table to simulate finding an item
+    mock_table = MagicMock()
+    mock_table.get_item.return_value = {
+        'Item': {
+            'id': 'a1b2c3d',
+            'long_url': 'https://www.example.com'
+        }
+    }
+    # Correctly patch the 'table' object in the redirect_service's app module
+    mocker.patch.object(app, 'table', mock_table)
+
+    event = {'pathParameters': {'short_id': 'a1b2c3d'}}
+    
+    ret = app.redirect_handler(event, "")
+
+    assert ret['statusCode'] == 302
+    assert ret['headers']['Location'] == 'https://www.example.com'
+
+def test_redirect_handler_not_found(mocker):
+    """Verifies a 404 is returned for a short_id that does not exist."""
+    mock_table = MagicMock()
+    # Simulate the case where get_item finds nothing
+    mock_table.get_item.return_value = {}
+    # Correctly patch the 'table' object in the redirect_service's app module
+    mocker.patch.object(app, 'table', mock_table)
+
+    event = {'pathParameters': {'short_id': 'nonexistent'}}
+
+    ret = app.redirect_handler(event, "")
+
+    assert ret['statusCode'] == 404


### PR DESCRIPTION
Merhaba Can abi
I've completed the Milestone 3. I've implemented the redirection service, so the short links should be fully working now
- Created a new `RedirectFunction` and put its code in a separate `redirect_service/` folder to keep things organized
- Updated the `template.yaml` file to add the new `GET /{short_id}` endpoint that triggers this function
- Wrote the Python code to look up the short ID in DynamoDB and return a 302 redirect
- Added unit tests for the new function, including one for the "404 Not Found" case as you suggested.

I guess this should cover everything for milestone 3. Could you review it when you have time
Thank you 